### PR TITLE
ガントチャートにおいて、検索結果表示項目が別ページ遷移して戻ってくると閉じてしまう

### DIFF
--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -7067,6 +7067,7 @@ var GanttComponent = function GanttComponent(props) {
   }, [data, endDateKey, startDateKey, store]);
   useEffect(function () {
     store.setColumns(columns);
+    store.initWidth();
   }, [columns, store]);
   useEffect(function () {
     store.setOnUpdate(onUpdate);

--- a/src/Gantt.tsx
+++ b/src/Gantt.tsx
@@ -110,6 +110,7 @@ const GanttComponent = <RecordType extends DefaultRecordType>(props: GanttProps<
   }, [data, endDateKey, startDateKey, store])
   useEffect(() => {
     store.setColumns(columns)
+    store.initWidth()
   }, [columns, store])
   useEffect(() => {
     store.setOnUpdate(onUpdate)


### PR DESCRIPTION
[Trello URL](https://trello.com/c/P1fGWkYV/3349-%E3%82%AC%E3%83%B3%E3%83%88%E3%83%81%E3%83%A3%E3%83%BC%E3%83%88%E3%81%AB%E3%81%8A%E3%81%84%E3%81%A6%E3%80%81%E6%A4%9C%E7%B4%A2%E7%B5%90%E6%9E%9C%E8%A1%A8%E7%A4%BA%E9%A0%85%E7%9B%AE%E3%81%8C%E5%88%A5%E3%83%9A%E3%83%BC%E3%82%B8%E9%81%B7%E7%A7%BB%E3%81%97%E3%81%A6%E6%88%BB%E3%81%A3%E3%81%A6%E3%81%8F%E3%82%8B%E3%81%A8%E9%96%89%E3%81%98%E3%81%A6%E3%81%97%E3%81%BE%E3%81%86)

以下に不具合が起こっていた流れを簡単にまとめます。

* ガントページから遷移して戻ってきた際、[この部分](https://github.com/h-basis/react-gantt/blob/1c5043233c95f040ade9778acef67edcf8d40b6a/src/Gantt.tsx#L107)で `GanttStore` が作成される。
* [`initWidth`](https://github.com/h-basis/react-gantt/blob/1c5043233c95f040ade9778acef67edcf8d40b6a/src/store.ts#L239) が呼び出される。このとき、 `tableWidth` に `totalColumnWidth` が代入される。
* [`totalColumnWidth`](https://github.com/h-basis/react-gantt/blob/1c5043233c95f040ade9778acef67edcf8d40b6a/src/store.ts#L317) は `getColumnsWidth` を元に計算される。
* [`getColumnsWidth`](https://github.com/h-basis/react-gantt/blob/1c5043233c95f040ade9778acef67edcf8d40b6a/src/store.ts#L303) は `this.columns` を参照するが、このときは初期化直後のため空配列になっている。そのため、 `totalColumnWidth` は 0 を返し、`tableWidth` に 0 が代入されるため、項目部分が隠されてしまう。
* その後、[この部分](https://github.com/h-basis/react-gantt/blob/1c5043233c95f040ade9778acef67edcf8d40b6a/src/Gantt.tsx#L112)で `setColumns` を呼び出すもの、 `tableWidth` が更新されないため、項目部分は隠れたままになる。

今回の修正では、 `setColumns` の後に明示的に `initWidth` を呼び出すことで、新しい `columns` を元に計算した `totalColumnWidth` を `tableWidth` に反映させました。
