### PR TITLE
Revert "ガントチャートにおいて、検索結果表示項目が別ページ遷移して戻ってくると閉じてしまう"

### DIFF
--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -7067,7 +7067,6 @@ var GanttComponent = function GanttComponent(props) {
   }, [data, endDateKey, startDateKey, store]);
   useEffect(function () {
     store.setColumns(columns);
-    store.initWidth();
   }, [columns, store]);
   useEffect(function () {
     store.setOnUpdate(onUpdate);

--- a/src/Gantt.tsx
+++ b/src/Gantt.tsx
@@ -110,7 +110,6 @@ const GanttComponent = <RecordType extends DefaultRecordType>(props: GanttProps<
   }, [data, endDateKey, startDateKey, store])
   useEffect(() => {
     store.setColumns(columns)
-    store.initWidth()
   }, [columns, store])
   useEffect(() => {
     store.setOnUpdate(onUpdate)


### PR DESCRIPTION
Reverts h-basis/react-gantt#3

20231223のリリースまでに本番デプロイが発生する場合はこれをマージする